### PR TITLE
Locale-based layout direction in FirstLaunchActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,4 +41,6 @@ dependencies {
     compile 'com.android.support:preference-v7:26.1.0'
     compile 'com.android.support:preference-v14:26.1.0'
     implementation 'com.android.support:support-v4:26.1.0'
+    compile 'com.android.support:support-core-ui:26.1.0'
+    compile 'com.duolingo.open:rtl-viewpager:1.0.2'
 }

--- a/app/src/main/java/io/github/kfaryarok/android/firstlaunch/FirstLaunchActivity.java
+++ b/app/src/main/java/io/github/kfaryarok/android/firstlaunch/FirstLaunchActivity.java
@@ -15,7 +15,6 @@ import io.github.kfaryarok.android.R;
 import io.github.kfaryarok.android.firstlaunch.pages.AlertsPageFirstLaunchFragment;
 import io.github.kfaryarok.android.firstlaunch.pages.ClassPageFirstLaunchFragment;
 import io.github.kfaryarok.android.firstlaunch.pages.LastPageFirstLaunchFragment;
-import io.github.kfaryarok.android.util.LayoutUtil;
 
 public class FirstLaunchActivity extends FragmentActivity {
 
@@ -33,7 +32,7 @@ public class FirstLaunchActivity extends FragmentActivity {
 
         ButterKnife.bind(this);
 
-        LayoutUtil.setDirection(this, LayoutUtil.LTR);
+        // LayoutUtil.setDirection(this, LayoutUtil.LTR);
 
         adapterPager = new PagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(adapterPager);

--- a/app/src/main/java/io/github/kfaryarok/android/firstlaunch/FirstLaunchPageFragment.java
+++ b/app/src/main/java/io/github/kfaryarok/android/firstlaunch/FirstLaunchPageFragment.java
@@ -3,10 +3,15 @@ package io.github.kfaryarok.android.firstlaunch;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.view.ViewCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
+
+import io.github.kfaryarok.android.R;
 
 /**
  * @author tbsc on 17/11/2017
@@ -25,6 +30,26 @@ public abstract class FirstLaunchPageFragment extends Fragment {
         // Inflate the layout for this fragment
         View view = inflater.inflate(getLayout(), container, false);
         return onAbstractCreateView(view);
+    }
+
+    /**
+     * Checks if the layout direction is set to RTL, and if so, it does the following:
+     * - The image of the previous button is changed to the next's image
+     * - The image of the next button is changed to the previous' image
+     * Needs to be called by each implementation of this class in {@link #onAbstractCreateView(View)}
+     * If one of the buttons don't exist, put in null.
+     * @param previous The previous page button, if there is one
+     * @param next The next page button, if there is one
+     */
+    protected void flipNavigationButtons(@Nullable ImageButton previous, @Nullable ImageButton next) {
+        if (ViewCompat.getLayoutDirection(getActivity().getWindow().getDecorView()) == ViewCompat.LAYOUT_DIRECTION_RTL) {
+            if (previous != null) {
+                previous.setImageResource(R.drawable.ic_navigate_next_black_24dp);
+            }
+            if (next != null) {
+                next.setImageResource(R.drawable.ic_navigate_before_black_24dp);
+            }
+        }
     }
 
     protected abstract View onAbstractCreateView(View view);

--- a/app/src/main/java/io/github/kfaryarok/android/firstlaunch/FirstLaunchViewPager.java
+++ b/app/src/main/java/io/github/kfaryarok/android/firstlaunch/FirstLaunchViewPager.java
@@ -1,14 +1,15 @@
 package io.github.kfaryarok.android.firstlaunch;
 
 import android.content.Context;
-import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+
+import com.duolingo.open.rtlviewpager.RtlViewPager;
 
 /**
  * @author tbsc on 20/11/2017
  */
-public class FirstLaunchViewPager extends ViewPager {
+public class FirstLaunchViewPager extends RtlViewPager {
 
     public FirstLaunchViewPager(Context context) {
         super(context);

--- a/app/src/main/java/io/github/kfaryarok/android/firstlaunch/pages/AlertsPageFirstLaunchFragment.java
+++ b/app/src/main/java/io/github/kfaryarok/android/firstlaunch/pages/AlertsPageFirstLaunchFragment.java
@@ -49,6 +49,8 @@ public class AlertsPageFirstLaunchFragment extends FirstLaunchPageFragment {
     protected View onAbstractCreateView(View view) {
         ButterKnife.bind(this, view);
 
+        flipNavigationButtons(previousPageButton, nextPageButton);
+
         LayoutUtil.setDirection(toggleCheckBox, LayoutUtil.RTL);
         LayoutUtil.setDirection(timePickerButton, LayoutUtil.RTL);
         LayoutUtil.setDirection(globalToggleCheckBox, LayoutUtil.RTL);

--- a/app/src/main/java/io/github/kfaryarok/android/firstlaunch/pages/ClassPageFirstLaunchFragment.java
+++ b/app/src/main/java/io/github/kfaryarok/android/firstlaunch/pages/ClassPageFirstLaunchFragment.java
@@ -34,27 +34,11 @@ public class ClassPageFirstLaunchFragment extends FirstLaunchPageFragment {
     @BindView(R.id.np_dialog_class_num)
     public NumberPicker numPicker;
 
-//    @BindView(R.id.rg_dialog_grade)
-//    public RadioGroup gradePicker;
-
     @BindView(R.id.cb_firstlaunch_show_all_updates)
     public CheckBox showAllCheckBox;
 
     @BindView(R.id.btn_firstlaunch_page1_next)
     public ImageButton nextPageButton;
-
-//    @BindView(R.id.rb_dialog_grade_g)
-//    public RadioButton gGradeRadioButton;
-//    @BindView(R.id.rb_dialog_grade_h)
-//    public RadioButton hGradeRadioButton;
-//    @BindView(R.id.rb_dialog_grade_i)
-//    public RadioButton iGradeRadioButton;
-//    @BindView(R.id.rb_dialog_grade_j)
-//    public RadioButton jGradeRadioButton;
-//    @BindView(R.id.rb_dialog_grade_k)
-//    public RadioButton kGradeRadioButton;
-//    @BindView(R.id.rb_dialog_grade_l)
-//    public RadioButton lGradeRadioButton;
 
     @BindView(R.id.gp_dialog_grade)
     public GradePicker gradePicker;
@@ -63,13 +47,12 @@ public class ClassPageFirstLaunchFragment extends FirstLaunchPageFragment {
     protected View onAbstractCreateView(View view) {
         ButterKnife.bind(this, view);
 
+        flipNavigationButtons(null, nextPageButton);
+
         numPicker.setMinValue(1);
         numPicker.setMaxValue(11);
         numPicker.setWrapSelectorWheel(false);
         numPicker.setSelected(true);
-
-        // only enable it after user puts in data
-        // nextPageButton.setEnabled(false);
 
         LayoutUtil.setDirection(selectorInclude, LayoutUtil.RTL);
         LayoutUtil.setDirection(showAllCheckBox, LayoutUtil.RTL);
@@ -86,21 +69,6 @@ public class ClassPageFirstLaunchFragment extends FirstLaunchPageFragment {
                     .putString(getString(R.string.pref_class_string), newGrade + classNum)
                     .apply();
         });
-//        gradePicker.setOnCheckedChangeListener(((group, checkedId) -> {
-//            String currentClass = PreferenceUtil.getActualStoredClassPreference(getContext());
-//            int classNum = ClassUtil.parseHebrewClassNumber(currentClass);
-//
-//            String newGrade = ClassPreferenceDialogFragmentCompat.convertGradeRadioButtonResToString(getContext(), checkedId);
-//
-//            PreferenceUtil.prefs(getContext()).edit()
-//                    .putString(getString(R.string.pref_class_string), newGrade + classNum)
-//                    .apply();
-//
-//            // a grade is selected and is assumed can't be deselected (radio buttons)
-//            // just enable going to the next page permanently
-//            // nextPageButton.setEnabled(true);
-//            allowNextPage = true;
-//        }));
 
         numPicker.setOnValueChangedListener(((picker, oldVal, newVal) -> {
             String currentClass = PreferenceUtil.getActualStoredClassPreference(getContext());
@@ -112,12 +80,6 @@ public class ClassPageFirstLaunchFragment extends FirstLaunchPageFragment {
         }));
 
         showAllCheckBox.setOnCheckedChangeListener(((buttonView, isChecked) -> {
-//            gGradeRadioButton.setEnabled(!isChecked);
-//            hGradeRadioButton.setEnabled(!isChecked);
-//            iGradeRadioButton.setEnabled(!isChecked);
-//            jGradeRadioButton.setEnabled(!isChecked);
-//            kGradeRadioButton.setEnabled(!isChecked);
-//            lGradeRadioButton.setEnabled(!isChecked);
             gradePicker.setEnabled(!isChecked);
             numPicker.setEnabled(!isChecked);
 

--- a/app/src/main/java/io/github/kfaryarok/android/firstlaunch/pages/LastPageFirstLaunchFragment.java
+++ b/app/src/main/java/io/github/kfaryarok/android/firstlaunch/pages/LastPageFirstLaunchFragment.java
@@ -26,6 +26,8 @@ public class LastPageFirstLaunchFragment extends FirstLaunchPageFragment {
     protected View onAbstractCreateView(View view) {
         ButterKnife.bind(this, view);
 
+        flipNavigationButtons(previousPageButton, null);
+
         finishButton.setOnClickListener(v -> {
             // finished setup, exit and remember first launch wizard ran
             PreferenceUtil.prefs(getContext()).edit()


### PR DESCRIPTION
The first launch on-boarding's flow direction is now based on the locale's direction. If the phone's language is Hebrew, it goes to the left, and if it's English, it goes to the right.
Thank you to Duolingo for making an RTL-supporting ViewPager and open sourcing it.