### PR TITLE
Refresh guard

### DIFF
--- a/app/src/main/java/io/github/kfaryarok/android/MainActivity.java
+++ b/app/src/main/java/io/github/kfaryarok/android/MainActivity.java
@@ -63,6 +63,14 @@ public class MainActivity extends AppCompatActivity implements UpdateAdapter.Upd
 
     public static boolean resumeFromFirstLaunch = false;
 
+    /**
+     * This is a little trick to prevent too many refreshes.
+     * If it's the first refresh, actually fetch.
+     * If it's the third refresh, actually fetch too.
+     * After that only fetch every fifth refresh.
+     */
+    private int refreshCount = 0;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // registering implicit receivers in API 26 can only be done programmatically
@@ -82,8 +90,11 @@ public class MainActivity extends AppCompatActivity implements UpdateAdapter.Upd
         swipeRefreshLayout.setOnRefreshListener(() -> {
             adapterRecyclerView.updates.clear();
             swipeRefreshLayout.setRefreshing(true);
-            UpdateHelper.getUpdatesReactively(this, true, nextConsumerAddToAdapter, Functions.emptyConsumer(),
+            UpdateHelper.getUpdatesReactively(this,
+                    refreshCount == 0 || refreshCount == 2 || refreshCount % 5 == 0,
+                    nextConsumerAddToAdapter, Functions.emptyConsumer(),
                     completeConsumerStopRefresh, Functions.emptyConsumer());
+            refreshCount++;
         });
     }
 


### PR DESCRIPTION
Instead of letting users refresh a ton of times and spam the servers, I added some guard, that will reduce the amount of connections to the server that can happen at a time.

First, third and fifth refreshes will fetch new data. After that only every fifth refresh will actually fetch data.